### PR TITLE
Add test for merchant name to link back to merchant show page

### DIFF
--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'merchant show page', type: :feature do
   describe 'As a user' do
     before :each do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+
     end
 
     it 'I can see a merchants name, address, city, state, zip' do
@@ -23,5 +25,23 @@ RSpec.describe 'merchant show page', type: :feature do
       expect(current_path).to eq("/merchants/#{@bike_shop.id}/items")
     end
 
+    it "has merchant name link" do
+      visit "/merchants"
+      click_link "Brian's Bike Shop"
+      expect(current_path).to eq("/merchants/#{@bike_shop.id}")
+
+      visit "/items"
+      click_link "Brian's Bike Shop"
+      expect(current_path).to eq("/merchants/#{@bike_shop.id}")
+
+      visit "/merchants/#{@bike_shop.id}/items"
+      click_link("Brian's Bike Shop", match: :first)
+      expect(current_path).to eq("/merchants/#{@bike_shop.id}")
+
+      visit "/items/#{@chain.id}"
+      click_link "Brian's Bike Shop"
+      expect(current_path).to eq("/merchants/#{@bike_shop.id}")
+
+    end
   end
 end


### PR DESCRIPTION
User can click a merchant's name on any page and go to that merchant's show page

Co-authored-by: Rachel Lew <48839191+rlew421@users.noreply.github.com>
Co-authored-by: Zac Isaacson <50255174+zacisaacson@users.noreply.github.com>