### PR TITLE
Add functionality to omit delete merchant button for merchants whose …

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,10 +1,13 @@
 class Merchant <ApplicationRecord
   has_many :items
-  
+
   validates_presence_of :name,
                         :address,
                         :city,
                         :state,
                         :zip
 
+  def items_in_order?
+    !items.joins(:item_orders).empty?
+  end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -4,5 +4,6 @@
 
 <ul><%= link_to "All #{@merchant.name} Items", "/merchants/#{@merchant.id}/items" %></ul>
 <ul><%= link_to "Update Merchant", "/merchants/#{@merchant.id}/edit" %></ul>
-<ul><%= link_to "Delete Merchant", "/merchants/#{@merchant.id}", method: :delete %>
-</ul>
+<% if !@merchant.items_in_order? %>
+  <ul><%= link_to "Delete Merchant", "/merchants/#{@merchant.id}", method: :delete %> </ul>
+<% end %>

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -5,12 +5,10 @@ RSpec.describe "As a visitor" do
     before (:each) do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
       @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
     end
     it "I can delete a merchant" do
 
       visit "merchants/#{@bike_shop.id}"
-
       click_on "Delete Merchant"
 
       expect(current_path).to eq('/merchants')
@@ -24,6 +22,19 @@ RSpec.describe "As a visitor" do
 
       expect(current_path).to eq('/merchants')
       expect(page).to_not have_content("Brian's Bike Shop")
+    end
+  end
+
+  describe "if a merchant has items that have been ordered" do
+    it "I cannot delete that merchant" do
+      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      order = Order.create(name: "Rambo", address: "234 Broadway", city: "Denver", state: "CO", zip: "84309")
+      item_order = ItemOrder.create(item_id: chain.id, order_id: order.id, item_price: chain.price, item_quantity: 2)
+
+      visit "/merchants/#{bike_shop.id}"
+
+      expect(page).to_not have_button("Delete Merchant")
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -12,4 +12,20 @@ describe Merchant, type: :model do
   describe "relationships" do
     it {should have_many :items}
   end
+
+  describe "methods" do
+    it "items_in_order? returns boolean if a merchant's items have been ordered" do
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      order = Order.create(name: "Rambo", address: "234 Broadway", city: "Denver", state: "CO", zip: "84309")
+      item_order = ItemOrder.create(item_id: chain.id, order_id: order.id, item_price: chain.price, item_quantity: 2)
+
+      actual = bike_shop.items_in_order?
+      expect(actual).to eq(true)
+
+      actual_2 = meg.items_in_order?
+      expect(actual_2).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Adds functionality to omit delete merchant button for merchants who items have been ordered.

Co-authored-by: Alice Post <26877629+ap2322@users.noreply.github.com>
Co-authored-by: Zac Isaacson  <50255174+zacisaacson@users.noreply.github.com>