### PR TITLE
Hide checkout button on cart show page when cart is empty

### DIFF
--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -23,4 +23,6 @@
 
 <p> Grand Total: <%= number_to_currency(cart.grand_total) %></p>
 <p><%= link_to "Empty Cart", "/cart/empty", method: :delete %></p>
-<%= button_to "Checkout", "/orders/new", method: :get %>
+<% if !@items.empty? %>
+  <%= button_to "Checkout", "/orders/new", method: :get %>
+<% end %>

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "cart show page" do
       expect(page).to_not have_content("Chain")
       expect(page).to_not have_content("Shimano Shifters")
       expect(current_path).to eq '/cart'
+      expect(page).to_not have_button("Checkout")
       within "#cart" do
         expect(page).to have_content("0")
       end


### PR DESCRIPTION
Add conditional to cart show page to hide button
Add expects to empty cart feature test
Co-authored-by: Rachel Lew <48839191+rlew421@users.noreply.github.com>
Co-authored-by: Zac Isaacson <50255174+zacisaacson@users.noreply.github.com>