### PR TITLE
Clean up test variables and spacing

### DIFF
--- a/spec/features/cart/cart_spec.rb
+++ b/spec/features/cart/cart_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "Across all pages" do
   it "has an indicator at the top showing a cart and the items in the cart" do
-    @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-    @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-    @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-    @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
+    meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    chain = meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+    shifter = meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
 
     visit '/merchants'
 
@@ -14,7 +14,7 @@ RSpec.describe "Across all pages" do
     end
 
 
-    visit "/items/#{@chain.id}"
+    visit "/items/#{chain.id}"
     click_button "Add to Cart"
 
     within "#cart" do
@@ -26,7 +26,7 @@ RSpec.describe "Across all pages" do
     expect(current_path).to eq("/items")
 
 
-    visit "/items/#{@shifter.id}"
+    visit "/items/#{shifter.id}"
     click_button "Add to Cart"
 
     within "#cart" do
@@ -38,7 +38,7 @@ RSpec.describe "Across all pages" do
     expect(current_path).to eq("/items")
 
 
-    visit "/items/#{@chain.id}"
+    visit "/items/#{chain.id}"
     click_button "Add to Cart"
 
     within "#cart" do

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 
 RSpec.describe "cart show page" do
   describe "when I've added items and visit my cart" do
+    before(:each) do
+      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
+    end
+
     it "I see all items in my cart along with their information:
     - the name of the item
     - the item image
@@ -10,11 +17,6 @@ RSpec.describe "cart show page" do
     - my desired quantity of the item
     - a subtotal (price multiplied by quantity)
     - grand total of what everything in my cart will cost" do
-
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
 
       visit "/items/#{@chain.id}"
       click_button "Add to Cart"
@@ -42,24 +44,14 @@ RSpec.describe "cart show page" do
     end
 
     it "shows an empty cart when no items are added" do
-
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
       visit "/cart"
+
       expect(page).to have_content("Your cart is empty")
       expect(page).to_not have_link("Empty cart")
       expect(page).to_not have_content("Gatorskins")
     end
 
     it "has a link to empty the cart" do
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
       visit "/items/#{@chain.id}"
       click_button "Add to Cart"
 
@@ -83,10 +75,6 @@ RSpec.describe "cart show page" do
     end
 
     it "can remove an individual item from cart" do
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
       visit "/items/#{@chain.id}"
       click_button "Add to Cart"
 
@@ -120,10 +108,6 @@ RSpec.describe "cart show page" do
     end
 
     it "can increment the count of an individual item according to inventory" do
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
       visit "/items/#{@chain.id}"
       click_button "Add to Cart"
 
@@ -150,10 +134,6 @@ RSpec.describe "cart show page" do
     end
 
     it "can decrement the count of an individual item according to inventory" do
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
       visit "/items/#{@chain.id}"
       click_button "Add to Cart"
 
@@ -188,10 +168,6 @@ RSpec.describe "cart show page" do
     end
 
     it "has a link to checkout" do
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
       visit "/items/#{@chain.id}"
       click_button "Add to Cart"
 
@@ -206,11 +182,5 @@ RSpec.describe "cart show page" do
 
       expect(current_path).to eq("/orders/new")
     end
-
-#     As a visitor
-# When I have items in my cart
-# And I visit my cart
-# I see a button or link to Checkout
-# When I click that button, I am taken to the new order page
   end
 end

--- a/spec/features/items/destroy_spec.rb
+++ b/spec/features/items/destroy_spec.rb
@@ -1,46 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe 'item delete', type: :feature do
+  before(:each) do
+    @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+
+  end
   describe 'when I visit an item show page' do
     it 'I can delete an item' do
-      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
-      visit "/items/#{chain.id}"
+      visit "/items/#{@chain.id}"
 
       expect(page).to have_link("Delete Item")
 
       click_on "Delete Item"
 
       expect(current_path).to eq("/items")
-      expect(page).to_not have_css("#item-#{chain.id}")
+      expect(page).to_not have_css("#item-#{@chain.id}")
     end
   end
 
   describe "when I delete an item with reviews" do
     it "deletes all the reviews of item" do
-      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      review_1 = chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
+      review_1 = @chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
 
-      visit "/items/#{chain.id}"
+      visit "/items/#{@chain.id}"
 
       click_on "Delete Item"
 
       expect(current_path).to eq("/items")
-      expect(page).to_not have_css("#item-#{chain.id}")
+      expect(page).to_not have_css("#item-#{@chain.id}")
       expect(Review.all).to eq([])
     end
   end
 
   describe "when an item is in an order" do
     it "cannot be deleted (doesn't have a link/button on page to delete)" do
-      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
       order = Order.create(name: "Rambo", address: "234 Broadway", city: "Denver", state: "CO", zip: "84309")
-      item_order = ItemOrder.create(item_id: chain.id, order_id: order.id, item_price: chain.price, item_quantity: 2)
+      item_order = ItemOrder.create(item_id: @chain.id, order_id: order.id, item_price: @chain.price, item_quantity: 2)
 
-      visit "/items/#{chain.id}"
+      visit "/items/#{@chain.id}"
 
       expect(page).to_not have_link("Delete Item")
     end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -6,10 +6,9 @@ RSpec.describe "As a Visitor" do
       before (:each) do
         @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
         @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-
       end
-      it 'I can see the prepopulated fields of that item' do
 
+      it 'I can see the prepopulated fields of that item' do
         visit "/items/#{@tire.id}"
 
         expect(page).to have_link("Edit Item")
@@ -26,7 +25,6 @@ RSpec.describe "As a Visitor" do
       end
 
       it 'I can change and update item with the form' do
-
         visit "/items/#{@tire.id}"
 
         click_on "Edit Item"

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe "Items Index Page" do
     before(:each) do
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @brian = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
-
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-
       @pull_toy = @brian.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", inventory: 32)
       @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
     end
@@ -24,7 +22,6 @@ RSpec.describe "Items Index Page" do
     end
 
     it "I can see a list of all of the items "do
-
       visit '/items'
 
       within "#item-#{@tire.id}" do
@@ -56,7 +53,6 @@ RSpec.describe "Items Index Page" do
         expect(page).to have_content("Sold by: #{@brian.name}")
         expect(page).to have_css("img[src*='#{@dog_bone.image}']")
       end
-
     end
   end
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -83,9 +83,4 @@ RSpec.describe 'item show page', type: :feature do
       end
     end
   end
-
-
-
-
-
 end

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "As a visitor" do
-  describe "When I visit a merchant show page" do
-    before (:each) do
-      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
-      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-    end
-    it "I can delete a merchant" do
+  before (:each) do
+    @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
+    @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+  end
 
+  describe "When I visit a merchant show page" do
+    it "I can delete a merchant" do
       visit "merchants/#{@bike_shop.id}"
       click_on "Delete Merchant"
 
@@ -27,12 +27,10 @@ RSpec.describe "As a visitor" do
 
   describe "if a merchant has items that have been ordered" do
     it "I cannot delete that merchant" do
-      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
       order = Order.create(name: "Rambo", address: "234 Broadway", city: "Denver", state: "CO", zip: "84309")
-      item_order = ItemOrder.create(item_id: chain.id, order_id: order.id, item_price: chain.price, item_quantity: 2)
+      item_order = ItemOrder.create(item_id: @chain.id, order_id: order.id, item_price: @chain.price, item_quantity: 2)
 
-      visit "/merchants/#{bike_shop.id}"
+      visit "/merchants/#{@bike_shop.id}"
 
       expect(page).to_not have_button("Delete Merchant")
     end
@@ -40,11 +38,9 @@ RSpec.describe "As a visitor" do
 
   describe "if a merchant has items that have not been ordered" do
     it "I can delete that merchant and all their items are deleted as well" do
-      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      review_1 = chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
+      review_1 = @chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
 
-      visit "/merchants/#{bike_shop.id}"
+      visit "/merchants/#{@bike_shop.id}"
       click_on "Delete Merchant"
 
       expect(current_path).to eq('/merchants')
@@ -53,7 +49,6 @@ RSpec.describe "As a visitor" do
       visit "/items"
 
       expect(page).to_not have_content("Chain")
-
     end
   end
 end

--- a/spec/features/merchants/edit_spec.rb
+++ b/spec/features/merchants/edit_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "As a Visitor" do
     before :each do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 11234)
     end
+
     it 'I can see prepopulated info on that user in the edit form' do
       visit "/merchants/#{@bike_shop.id}"
       click_on "Update Merchant"
@@ -44,6 +45,5 @@ RSpec.describe "As a Visitor" do
       expect(page).to have_content("Merchant not updated, please fill in all fields")
       expect(page).to have_button("Update Merchant")
     end
-
   end
 end

--- a/spec/features/merchants/new_spec.rb
+++ b/spec/features/merchants/new_spec.rb
@@ -2,47 +2,42 @@ require 'rails_helper'
 
 RSpec.describe 'merchant new page', type: :feature do
   describe 'As a user' do
+    before(:each) do
+      @name = "Sal's Calz(ones)"
+      @address = '123 Kindalikeapizza Dr.'
+      @city = "Denver"
+      @state = "CO"
+      @zip = 80204
+    end
     it 'I can create a new merchant' do
       visit '/merchants/new'
 
-      name = "Sal's Calz(ones)"
-      address = '123 Kindalikeapizza Dr.'
-      city = "Denver"
-      state = "CO"
-      zip = 80204
-
-      fill_in :name, with: name
-      fill_in :address, with: address
-      fill_in :city, with: city
-      fill_in :state, with: state
-      fill_in :zip, with: zip
+      fill_in :name, with: @name
+      fill_in :address, with: @address
+      fill_in :city, with: @city
+      fill_in :state, with: @state
+      fill_in :zip, with: @zip
 
       click_button "Create Merchant"
 
       new_merchant = Merchant.last
 
       expect(current_path).to eq('/merchants')
-      expect(page).to have_content(name)
-      expect(new_merchant.name).to eq(name)
-      expect(new_merchant.address).to eq(address)
-      expect(new_merchant.city).to eq(city)
-      expect(new_merchant.state).to eq(state)
-      expect(new_merchant.zip).to eq(zip)
+      expect(page).to have_content(@name)
+      expect(new_merchant.name).to eq(@name)
+      expect(new_merchant.address).to eq(@address)
+      expect(new_merchant.city).to eq(@city)
+      expect(new_merchant.state).to eq(@state)
+      expect(new_merchant.zip).to eq(@zip)
     end
 
     it "doesn't create a new merchant and shows flash message with incomplete information" do
       visit '/merchants/new'
 
-      name = "Sal's Calz(ones)"
-      address = '123 Kindalikeapizza Dr.'
-      city = "Denver"
-      state = "CO"
-      zip = 80204
-
-      fill_in :name, with: name
-      fill_in :address, with: address
-      fill_in :state, with: state
-      fill_in :zip, with: zip
+      fill_in :name, with: @name
+      fill_in :address, with: @address
+      fill_in :state, with: @state
+      fill_in :zip, with: @zip
 
       click_button "Create Merchant"
 

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'merchant show page', type: :feature do
     before :each do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
       @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
     end
 
     it 'I can see a merchants name, address, city, state, zip' do
@@ -17,11 +16,9 @@ RSpec.describe 'merchant show page', type: :feature do
 
     it 'I can see a link to visit the merchant items' do
       visit "/merchants/#{@bike_shop.id}"
-
       expect(page).to have_link("All #{@bike_shop.name} Items")
 
       click_on "All #{@bike_shop.name} Items"
-
       expect(current_path).to eq("/merchants/#{@bike_shop.id}/items")
     end
 

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,21 +1,18 @@
-
 require 'rails_helper'
 
 RSpec.describe 'Site Navigation' do
   describe 'As a Visitor' do
     it "I see a nav bar with links to all pages" do
       visit '/merchants'
-
       within 'nav' do
         click_link 'All Items'
       end
 
       expect(current_path).to eq('/items')
-
       within 'nav' do
         click_link 'All Merchants'
       end
-
+      
       expect(current_path).to eq('/merchants')
     end
   end

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "On the Checkout Page (aka New Order page)" do
+  before(:each) do
+    @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+    @shifter = @meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
+  end
+
   describe "details of the cart are on the page" do
     it "and it has a form to make a new order with
         - name
@@ -8,30 +15,26 @@ RSpec.describe "On the Checkout Page (aka New Order page)" do
         - city
         - state
         -zip" do
-      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      chain = meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      shifter = meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
 
-      visit "/items/#{chain.id}"
+      visit "/items/#{@chain.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
 
       visit '/orders/new'
-      within "#item-#{chain.id}" do
-        expect(page).to have_content(chain.name)
-        expect(page).to have_content(chain.merchant.name)
-        expect(page).to have_content(chain.price)
+      within "#item-#{@chain.id}" do
+        expect(page).to have_content(@chain.name)
+        expect(page).to have_content(@chain.merchant.name)
+        expect(page).to have_content(@chain.price)
         expect(page).to have_content("Quantity: 1")
         expect(page).to have_content("Subtotal: $50.00")
       end
-      within "#item-#{shifter.id}" do
-        expect(page).to have_content(shifter.name)
-        expect(page).to have_content(shifter.merchant.name)
-        expect(page).to have_content(shifter.price)
+      within "#item-#{@shifter.id}" do
+        expect(page).to have_content(@shifter.name)
+        expect(page).to have_content(@shifter.merchant.name)
+        expect(page).to have_content(@shifter.price)
         expect(page).to have_content("Quantity: 2")
         expect(page).to have_content("Subtotal: $360.00")
       end
@@ -50,16 +53,11 @@ RSpec.describe "On the Checkout Page (aka New Order page)" do
 
   describe "when user fills out order form" do
     it "creates a new order" do
-      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      chain = meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      shifter = meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
-      visit "/items/#{chain.id}"
+      visit "/items/#{@chain.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
 
       visit '/orders/new'
@@ -81,15 +79,15 @@ RSpec.describe "On the Checkout Page (aka New Order page)" do
       expect(page).to have_content("CO")
       expect(page).to have_content("80004")
 
-      expect(page).to have_content(chain.name)
-      expect(page).to have_content(chain.merchant.name)
-      expect(page).to have_content(chain.price)
+      expect(page).to have_content(@chain.name)
+      expect(page).to have_content(@chain.merchant.name)
+      expect(page).to have_content(@chain.price)
       expect(page).to have_content("Quantity: 1")
       expect(page).to have_content("Subtotal: $50.00")
 
-      expect(page).to have_content(shifter.name)
-      expect(page).to have_content(shifter.merchant.name)
-      expect(page).to have_content(shifter.price)
+      expect(page).to have_content(@shifter.name)
+      expect(page).to have_content(@shifter.merchant.name)
+      expect(page).to have_content(@shifter.price)
       expect(page).to have_content("Quantity: 2")
       expect(page).to have_content("Subtotal: $360.00")
 
@@ -103,16 +101,11 @@ RSpec.describe "On the Checkout Page (aka New Order page)" do
 
   describe "when I click Create Order without filling in all fields" do
     it "has a flash message for an incomplete form" do
-      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      chain = meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      shifter = meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
-      visit "/items/#{chain.id}"
+      visit "/items/#{@chain.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
 
       visit '/orders/new'
@@ -131,16 +124,11 @@ RSpec.describe "On the Checkout Page (aka New Order page)" do
 
   describe "When I make an order" do
     it "empties our cart" do
-      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      chain = meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-      shifter = meg.items.create(name: "Shimano Shifters", description: "It'll always shift!", active?: false, price: 180, image: "https://images-na.ssl-images-amazon.com/images/I/4142WWbN64L._SX466_.jpg", inventory: 2)
-
-      visit "/items/#{chain.id}"
+      visit "/items/#{@chain.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
-      visit "/items/#{shifter.id}"
+      visit "/items/#{@shifter.id}"
       click_button "Add to Cart"
 
       visit '/orders/new'

--- a/spec/features/reviews/destroy_spec.rb
+++ b/spec/features/reviews/destroy_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "delete review" do
   before(:each) do
     @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
     @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
     @review_1 = @chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
   end
+  
   it "I can click a link to delete the review" do
     visit "/items/#{@chain.id}"
 

--- a/spec/features/reviews/edit_spec.rb
+++ b/spec/features/reviews/edit_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "Edit a Review" do
   before(:each) do
     @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
     @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
     @review_1 = @chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
   end
 
@@ -40,20 +39,6 @@ RSpec.describe "Edit a Review" do
 
       expect(page).to have_content("Review not updated. Please fill in all fields.")
       expect(page).to have_button("Update Review")
-
     end
   end
 end
-
-
-# As a visitor,
-# When I visit an item's show page
-# I see a link to edit the review next to each review.
-# When I click on this link, I am taken to an edit review path
-# On this new page, I see a form that includes:
-# - title
-# - numeric rating
-# - text of the review itself
-# I can update any of these fields and submit the form.
-# When the form is submitted, I should return to that item's
-# show page and I should see my updated review

--- a/spec/features/reviews/new_spec.rb
+++ b/spec/features/reviews/new_spec.rb
@@ -5,15 +5,12 @@ RSpec.describe "review create page" do
     before(:each) do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
       @review_1 = @chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
       @review_2 = @chain.reviews.create(title: "This blew my mind", content: "goddawful", rating: 1)
     end
 
     describe "I can click a link to create a review" do
       it "I can make a new review through a form" do
-
-
         visit "/items/#{@chain.id}"
 
         click_link "Review This Item"
@@ -31,10 +28,10 @@ RSpec.describe "review create page" do
         expect(page).to have_content("Off the chain.")
       end
     end
+
     describe "with incomplete review" do
       it "shows a flash message" do
         visit "/items/#{@chain.id}/reviews/new"
-
 
         fill_in :title, with: "Cool chain dude."
         fill_in :content, with: "Off the chain."
@@ -43,7 +40,6 @@ RSpec.describe "review create page" do
 
         expect(page).to have_content("Review not created. Please fill in all fields")
         expect(page).to have_button("Submit Review")
-
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,14 +15,12 @@ describe Item, type: :model do
     it {should have_many(:reviews).dependent(:destroy) }
     it {should have_many(:item_orders).dependent(:destroy) }
     it {should have_many(:orders).through(:item_orders)}
-
   end
 
   describe "methods" do
     before (:each) do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
-
       @review_1 = @chain.reviews.create(title: "This stunk", content: "super smelly", rating: 1)
       @review_2 = @chain.reviews.create(title: "This blew my mind", content: "goddawful", rating: 1)
       @review_3 = @chain.reviews.create(title: "This was great", content: "It worked just as described", rating: 5)

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -11,5 +11,4 @@ describe Review, type: :model do
   describe "relationships" do
     it { should belong_to :item}
   end
-
 end


### PR DESCRIPTION
Went through all feature and model tests to pull reused scenarios into before(:each) and remove extra spacing. 
All cosmetic, no functional differences.

Co-authored-by: Rachel Lew <48839191+rlew421@users.noreply.github.com>
Co-authored-by: Zac Isaacson <50255174+zacisaacson@users.noreply.github.com>